### PR TITLE
Put trackers to kinesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ It includes a form allowing authorized users to fill in:
 After submitting the form, the request is signed with a `?s=` query param, and is
 now a valid pixel tracker url.
 
+## Environment variables
+
+- `DESTINATIONS` a comma separated list of `dataset.table` BigQuery tables to
+  include on the admin page dropdown.
+- `ID_HOST` the PRX ID server used to authenticate users for access to the admin page
+- `KINESIS_STREAM` the destination stream for tracked pixels
+- `SIGNER_SECRET` a secret string used to sign pixel query parameters
+
 # Installation
 
 To get started, first install dev dependencies with `yarn`.  Then run `yarn test`.  End of list!

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,0 +1,20 @@
+exports.__kinesisPuts = []
+beforeEach(() => exports.__kinesisPuts = [])
+
+/**
+ * Just log kinesis calls
+ */
+exports.Kinesis = class FakeKinesis {
+  putRecord(data) {
+    return {
+      promise: async () => {
+        if (data.Data && data.Data.match(/throw/)) {
+          throw new Error('FakeKinesis throws error')
+        } else {
+          exports.__kinesisPuts.push(data)
+          return null
+        }
+      }
+    }
+  }
+}

--- a/env-example
+++ b/env-example
@@ -1,4 +1,4 @@
 DESTINATIONS=some_table,another_table
 ID_HOST=id.prx.org
-KINESIS_STREAM=
+KINESIS_STREAM=some-stream-name
 SIGNER_SECRET=some-random-string

--- a/env-example
+++ b/env-example
@@ -1,3 +1,4 @@
 DESTINATIONS=some_table,another_table
 ID_HOST=id.prx.org
+KINESIS_STREAM=
 SIGNER_SECRET=some-random-string

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -15,5 +15,10 @@ exports.put = async function(json) {
     StreamName = StreamName.split('/').pop()
   }
 
-  await kinesis.putRecord({Data, PartitionKey, StreamName}).promise()
+  if (StreamName) {
+    await kinesis.putRecord({Data, PartitionKey, StreamName}).promise()
+    return true
+  } else {
+    return false
+  }
 }

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -1,0 +1,19 @@
+const AWS = require('aws-sdk')
+const crypto = require('crypto')
+const kinesis = new AWS.Kinesis({region: process.env.AWS_REGION || 'us-east-1'})
+
+/**
+ * Write a pixel tracker record to kinesis
+ */
+exports.put = async function(json) {
+  const Data = JSON.stringify(json)
+  const PartitionKey = crypto.createHash('md5').update(Data).digest('hex')
+
+  // convert full arns to stream name
+  let StreamName = process.env.KINESIS_STREAM || ''
+  if (StreamName.indexOf('/') > -1) {
+    StreamName = StreamName.split('/').pop()
+  }
+
+  await kinesis.putRecord({Data, PartitionKey, StreamName}).promise()
+}

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -1,0 +1,49 @@
+jest.mock('aws-sdk')
+
+const sdk = require('aws-sdk')
+const kinesis = require('./kinesis')
+
+
+describe('kinesis', () => {
+
+  it('puts data to kinesis', async () => {
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(1)
+    expect(sdk.__kinesisPuts[0].Data).toEqual('{"foo":"bar"}')
+  })
+
+  it('sets a unique partition key', async () => {
+    await kinesis.put({foo: 'bar1'})
+    await kinesis.put({foo: 'bar1'})
+    await kinesis.put({foo: 'bar2'})
+    await kinesis.put({foo: 'bar3'})
+    expect(sdk.__kinesisPuts.length).toEqual(4)
+    expect(sdk.__kinesisPuts[0].PartitionKey).toEqual(sdk.__kinesisPuts[1].PartitionKey)
+    expect(sdk.__kinesisPuts[0].PartitionKey).not.toEqual(sdk.__kinesisPuts[2].PartitionKey)
+    expect(sdk.__kinesisPuts[0].PartitionKey).not.toEqual(sdk.__kinesisPuts[3].PartitionKey)
+  })
+
+  it('sets a kinesis stream', async () => {
+    process.env.KINESIS_STREAM = 'anything'
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(1)
+    expect(sdk.__kinesisPuts[0].StreamName).toEqual('anything')
+  })
+
+  it('decodes kinesis stream arns', async () => {
+    process.env.KINESIS_STREAM = 'arn:aws:kinesis:us-east-1:12345678:stream/anything'
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(1)
+    expect(sdk.__kinesisPuts[0].StreamName).toEqual('anything')
+  })
+
+  it('throws kinesis errors', async () => {
+    try {
+      await kinesis.put({throw: true})
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(err.message).toMatch(/FakeKinesis throws error/)
+    }
+  })
+
+})

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -6,6 +6,8 @@ const kinesis = require('./kinesis')
 
 describe('kinesis', () => {
 
+  beforeEach(() => process.env.KINESIS_STREAM = 'test-stream')
+
   it('puts data to kinesis', async () => {
     await kinesis.put({foo: 'bar'})
     expect(sdk.__kinesisPuts.length).toEqual(1)
@@ -28,6 +30,12 @@ describe('kinesis', () => {
     await kinesis.put({foo: 'bar'})
     expect(sdk.__kinesisPuts.length).toEqual(1)
     expect(sdk.__kinesisPuts[0].StreamName).toEqual('anything')
+  })
+
+  it('ignores puts with no stream set', async () => {
+    process.env.KINESIS_STREAM = ''
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(0)
   })
 
   it('decodes kinesis stream arns', async () => {

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -1,4 +1,5 @@
 const log = require('lambda-log')
+const kinesis = require('./kinesis')
 const signer = require('./signer')
 const util = require('./util')
 
@@ -10,23 +11,26 @@ exports.log = async (query, headers, identity) => {
   headers = headers || {}
   identity = identity || {}
 
-  const agent = headers['user-agent']
-  const ip = headers['x-forwarded-for'] || identity['sourceIp']
-  const referrer = headers['referer']
+  const remoteAgent = headers['user-agent']
+  const remoteIp = headers['x-forwarded-for'] || identity['sourceIp']
+  const remoteReferrer = headers['referer']
+
+  // kinesis record MUST match analytics-ingest-lambda PixelTrackers input
   const data = {
     key: query['k'],
     canonical: query['c'],
     destination: query['d'],
-    agent,
-    ip,
-    referrer,
+    remoteAgent,
+    remoteIp,
+    remoteReferrer,
   }
 
-  const reason = skipReason(query, agent, ip)
+  const reason = skipReason(query, remoteAgent, remoteIp)
   if (reason) {
     log.info('skip', {reason, ...data})
   } else {
     log.info('track', data)
+    await kinesis.put({type: 'pixel', timestamp: Date.now(), ...data})
   }
 }
 

--- a/lib/tracker.test.js
+++ b/lib/tracker.test.js
@@ -9,7 +9,14 @@ describe('tracker', () => {
   const query = signer.signObject({k: 'my-key', c: 'my-url', d: 'my-dest'})
   const headers = {'user-agent': 'my-agent', 'x-forwarded-for': 'my-ip', 'referer': 'my-ref'}
   const identity = {sourceIp: 'source-ip'}
-  const myData = {agent: 'my-agent', canonical: 'my-url', destination: 'my-dest', ip: 'my-ip', key: 'my-key', referrer: 'my-ref'}
+  const myData = {
+    canonical: 'my-url',
+    destination: 'my-dest',
+    key: 'my-key',
+    remoteAgent: 'my-agent',
+    remoteIp: 'my-ip',
+    remoteReferrer: 'my-ref',
+  }
 
   it('tracks pixel impressions', async () => {
     await tracker.log(query, headers)
@@ -50,35 +57,35 @@ describe('tracker', () => {
     await tracker.log(query, {...headers, 'user-agent': null})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('skip')
-    expect(log.__info[0].data).toEqual({...myData, agent: null, reason: 'no-agent'})
+    expect(log.__info[0].data).toEqual({...myData, remoteAgent: null, reason: 'no-agent'})
   })
 
   it('falls back to the identity source ip', async () => {
     await tracker.log(query, {...headers, 'x-forwarded-for': null}, identity)
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('track')
-    expect(log.__info[0].data).toEqual({...myData, ip: 'source-ip'})
+    expect(log.__info[0].data).toEqual({...myData, remoteIp: 'source-ip'})
   })
 
   it('skips lack of ip address', async () => {
     await tracker.log(query, {...headers, 'x-forwarded-for': null}, {sourceIp: null})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('skip')
-    expect(log.__info[0].data).toEqual({...myData, ip: null, reason: 'no-ip'})
+    expect(log.__info[0].data).toEqual({...myData, remoteIp: null, reason: 'no-ip'})
   })
 
   it('allows lack of referrer', async () => {
     await tracker.log(query, {...headers, 'referer': undefined})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('track')
-    expect(log.__info[0].data).toEqual({...myData, referrer: undefined})
+    expect(log.__info[0].data).toEqual({...myData, remoteReferrer: undefined})
   })
 
   it('skips bots', async () => {
     await tracker.log(query, {...headers, 'user-agent': 'GoogleBot'})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('skip')
-    expect(log.__info[0].data).toEqual({...myData, agent: 'GoogleBot', reason: 'bot'})
+    expect(log.__info[0].data).toEqual({...myData, remoteAgent: 'GoogleBot', reason: 'bot'})
   })
 
 })

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lambda-log": "^2.2.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.448.0",
     "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "jest": "^24.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,21 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
+aws-sdk@^2.448.0:
+  version "2.448.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.448.0.tgz#1afa8bc1616aa6bacba393d70923e4294febe430"
+  integrity sha512-RMmdxP0VgI8eq7SehOHINULL6BL84wy9jOngQwJnxCPT/3/5jUuexKjzeFpdXTS4+dVToqj8q9THAbqzuXZ9dQ==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -513,6 +528,11 @@ babel-preset-jest@^24.6.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -604,6 +624,15 @@ bser@^2.0.0:
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1080,6 +1109,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -1510,6 +1544,16 @@ iconv-lite@0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -1747,7 +1791,7 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -2161,6 +2205,11 @@ jest@^24.7.1:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.7.1"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -2952,6 +3001,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2968,6 +3022,11 @@ qs@^6.5.1:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.0:
   version "1.2.0"
@@ -3185,7 +3244,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -3682,6 +3746,14 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -3701,7 +3773,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
@@ -3836,6 +3908,19 @@ xdg-basedir@^3.0.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
For #2.  Send signed and non-bot pixel requests to a kinesis stream.

PRX/analytics-ingest-lambda#39 should be merged/deployed first.