### PR TITLE
Cookie ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ user to kinesis, for later processing and shipping to BigQuery by the
 [analytics-ingest-lambda](https://github.com/PRX/analytics-ingest-lambda).
 
 In order for a request to be recorded by the pixel tracker, 5 pieces of information
-must be present, and 2 optional:
+must be present, and 3 optional:
 
 1. A string `?k=` key query param.
 2. A string `?c=` canonical-url query param.
@@ -19,6 +19,10 @@ must be present, and 2 optional:
 5. A non-bot user-agent header.
 6. _(optional)_ An `x-forwarded-for` header. Defaults to the source-ip of the request.
 7. _(optional)_ A `referer` header.
+8. _(optional)_ A `cookie` header containing the `_pxid` key
+
+Additionally, requests without a cookie will be redirected from `/i.gif` to
+`/r.gif` in an attempt to set the optional `_pxid` cookie.
 
 With all those present, a record will be put to the `KINESIS_STREAM` env stream
 name, containing a json object:
@@ -32,7 +36,8 @@ name, containing a json object:
   "canonical": "https://www.prx.org/url1",
   "remoteAgent": "some-user-agent",
   "remoteIp": "50.21.204.248, 127.0.0.1",
-  "remoteReferrer": "https://www.prx.org/technology/"
+  "remoteReferrer": "https://www.prx.org/technology/",
+  "userId": "my-user-id-string"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ It includes a form allowing authorized users to fill in:
 After submitting the form, the request is signed with a `?s=` query param, and is
 now a valid pixel tracker url.
 
+## Environment variables
+
+- `DESTINATIONS` a comma separated list of `dataset.table` BigQuery tables to
+  include on the admin page dropdown.
+- `ID_HOST` the PRX ID server used to authenticate users for access to the admin page
+- `KINESIS_STREAM` the destination stream for tracked pixels
+- `SIGNER_SECRET` a secret string used to sign pixel query parameters
+
 # Installation
 
 To get started, first install dev dependencies with `yarn`.  Then run `yarn test`.  End of list!

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,0 +1,20 @@
+exports.__kinesisPuts = []
+beforeEach(() => exports.__kinesisPuts = [])
+
+/**
+ * Just log kinesis calls
+ */
+exports.Kinesis = class FakeKinesis {
+  putRecord(data) {
+    return {
+      promise: async () => {
+        if (data.Data && data.Data.match(/throw/)) {
+          throw new Error('FakeKinesis throws error')
+        } else {
+          exports.__kinesisPuts.push(data)
+          return null
+        }
+      }
+    }
+  }
+}

--- a/dev-server.js
+++ b/dev-server.js
@@ -21,6 +21,7 @@ app.use(async (req, res) => {
     const data = await handler.handler(event)
     if (data.statusCode) {
       res.status(data.statusCode)
+      res.set(data.headers || {})
       if (data.body && data.isBase64Encoded) {
         const buff = Buffer.from(data.body, 'base64')
         res.send(buff)

--- a/env-example
+++ b/env-example
@@ -1,4 +1,4 @@
 DESTINATIONS=some_table,another_table
 ID_HOST=id.prx.org
-KINESIS_STREAM=
+KINESIS_STREAM=some-stream-name
 SIGNER_SECRET=some-random-string

--- a/env-example
+++ b/env-example
@@ -1,3 +1,4 @@
 DESTINATIONS=some_table,another_table
 ID_HOST=id.prx.org
+KINESIS_STREAM=
 SIGNER_SECRET=some-random-string

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
+const cookie = require('cookie')
 const log = require('lambda-log')
+const uuidv4 = require('uuid/v4')
 const util = require('./lib/util')
 const pages = require('./lib/pages')
 const tracker = require('./lib/tracker')
+const COOKIE_NAME = '_pxid'
 
 /**
  * Serve a 1x1 pixel and log metrics
@@ -11,6 +14,7 @@ exports.handler = async (event) => {
     const query = event.queryStringParameters || {}
     const headers = util.keysToLowerCase(event.headers) || {}
     const identity = (event.requestContext || {}).identity || {}
+    const userId = cookie.parse(headers['cookie'] || '')[COOKIE_NAME]
 
     if (event.httpMethod !== 'GET' && event.httpMethod !== 'HEAD') {
       return util.text(405, 'Method not allowed')
@@ -18,9 +22,15 @@ exports.handler = async (event) => {
       return pages.home()
     } else if (event.path === '/admin') {
       return await pages.admin(query, headers)
-    } else if (event.path === '/i.gif') {
-      await tracker.log(query, headers, identity)
+    } else if ((event.path === '/i.gif' && userId) || event.path === '/r.gif') {
+      await tracker.log(query, headers, identity, userId)
       return util.pixel()
+    } else if (event.path === '/i.gif') {
+      const params = util.encodeQuery(query)
+      const domain = headers['host']
+      const expires = util.future(1)
+      const setCookie = cookie.serialize(COOKIE_NAME, uuidv4(), {domain, expires})
+      return util.redirect(`/r.gif${params}`, setCookie)
     } else {
       return util.text(404, 'Pixel not found')
     }

--- a/index.test.js
+++ b/index.test.js
@@ -2,6 +2,7 @@ jest.mock('lambda-log')
 jest.mock('./lib/tracker')
 
 const log = require('lambda-log')
+const signer = require('./lib/signer')
 const tracker = require('./lib/tracker')
 const {handler} = require('./index')
 
@@ -11,6 +12,7 @@ describe('index', () => {
     httpMethod: 'GET',
     path: '/i.gif',
     headers: {
+      'cookie': '_pxid=my-user-id',
       'user-agent': 'my-agent',
       'x-forwarded-for': '98.76.54.321',
       'referer': 'https://www.prx.org/',
@@ -18,12 +20,24 @@ describe('index', () => {
     queryStringParameters: {
       k: 'my-key-here',
       c: 'http://the.canonical/url',
+      d: 'the-destination',
     },
     requestContext: {
       identity: {
         sourceIp: '123.456.78.9'
       },
     },
+  }
+  event.queryStringParameters = signer.signObject(event.queryStringParameters)
+
+  const logged = {
+    canonical: 'http://the.canonical/url',
+    destination: 'the-destination',
+    key: 'my-key-here',
+    remoteAgent: 'my-agent',
+    remoteIp: '98.76.54.321',
+    remoteReferrer: 'https://www.prx.org/',
+    userId: 'my-user-id',
   }
 
   it('returns a pixel', async () => {
@@ -33,6 +47,53 @@ describe('index', () => {
     expect(resp.headers['content-length']).toEqual(35)
     expect(resp.isBase64Encoded).toEqual(true)
     expect(Buffer.from(resp.body, 'base64').byteLength).toEqual(35)
+    expect(tracker.__skips.length).toEqual(0)
+    expect(tracker.__tracks.length).toEqual(1)
+    expect(tracker.__tracks[0]).toEqual(logged)
+  })
+
+  it('returns a pixel and skips', async () => {
+    const resp = await handler({...event, queryStringParameters: {}})
+    expect(resp.statusCode).toEqual(200)
+    expect(resp.headers['content-type']).toEqual('image/gif')
+    expect(tracker.__tracks.length).toEqual(0)
+    expect(tracker.__skips.length).toEqual(1)
+    expect(tracker.__skips[0]).toEqual({...logged, canonical: undefined, key: undefined, destination: undefined})
+    expect(tracker.__reasons[0]).toEqual('invalid')
+  })
+
+  it('returns a redirect pixel', async () => {
+    const resp = await handler({...event, path: '/r.gif'})
+    expect(resp.statusCode).toEqual(200)
+    expect(resp.headers['content-type']).toEqual('image/gif')
+    expect(tracker.__skips.length).toEqual(0)
+    expect(tracker.__tracks.length).toEqual(1)
+    expect(tracker.__tracks[0]).toEqual(logged)
+  })
+
+  it('returns a redirect pixel without a cookie', async () => {
+    const resp = await handler({...event, headers: {...event.headers, cookie: ''}, path: '/r.gif'})
+    expect(resp.statusCode).toEqual(200)
+    expect(resp.headers['content-type']).toEqual('image/gif')
+    expect(tracker.__skips.length).toEqual(0)
+    expect(tracker.__tracks.length).toEqual(1)
+    expect(tracker.__tracks[0]).toEqual({...logged, userId: undefined})
+  })
+
+  it('redirects to a pixel with a cookie', async () => {
+    const resp = await handler({...event, headers: {host: 'my.host.name'}})
+    const sign = event.queryStringParameters.s
+    const loc = `/r.gif?k=my-key-here&c=http%3A%2F%2Fthe.canonical%2Furl&d=the-destination&s=${sign}`
+    expect(resp.statusCode).toEqual(302)
+    expect(resp.headers['content-type']).toEqual('text/plain')
+    expect(resp.headers['location']).toEqual(loc)
+    expect(tracker.__skips.length).toEqual(0)
+    expect(tracker.__tracks.length).toEqual(0)
+
+    const cookie = resp.headers['set-cookie'] || ''
+    expect(cookie).toMatch(/_pxid=[^;]+;/)
+    expect(cookie).toMatch(/Expires=[^;]+/)
+    expect(cookie).toMatch(/Domain=my\.host\.name/)
   })
 
   it('returns the homepage', async () => {
@@ -42,25 +103,16 @@ describe('index', () => {
     expect(resp.body).toMatch('<html>')
   })
 
-  it('tracks impressions', async () => {
-    expect(await handler(event)).toMatchObject({statusCode: 200})
-    expect(tracker.__log.length).toEqual(1)
-    expect(tracker.__log[0].query).toEqual({k: 'my-key-here', c: 'http://the.canonical/url'})
-    expect(tracker.__log[0].headers).toEqual({
-      'user-agent': 'my-agent',
-      'x-forwarded-for': '98.76.54.321',
-      'referer': 'https://www.prx.org/',
-    })
-  })
-
   it('lowercases header values', async () => {
-    const headers = {'User-Agent': 'agent2', 'x-FORwarDED-for': 'ip2', 'Referer': 'ref2'}
+    const headers = {'CoOkie': '_pxid=my-user-id', 'User-Agent': 'agent2', 'x-FORwarDED-for': 'ip2', 'Referer': 'ref2'}
     expect(await handler({...event, headers})).toMatchObject({statusCode: 200})
-    expect(tracker.__log.length).toEqual(1)
-    expect(tracker.__log[0].headers).toEqual({
-      'user-agent': 'agent2',
-      'x-forwarded-for': 'ip2',
-      'referer': 'ref2',
+    expect(tracker.__skips.length).toEqual(0)
+    expect(tracker.__tracks.length).toEqual(1)
+    expect(tracker.__tracks[0]).toEqual({
+      ...logged,
+      remoteAgent: 'agent2',
+      remoteIp: 'ip2',
+      remoteReferrer: 'ref2',
     })
   })
 
@@ -85,8 +137,8 @@ describe('index', () => {
   it('falls back to the source ip', async () => {
     const headers = {...event.headers, 'x-forwarded-for': undefined}
     expect(await handler({...event, headers})).toMatchObject({statusCode: 200})
-    expect(tracker.__log.length).toEqual(1)
-    expect(tracker.__log[0].identity).toEqual({sourceIp: '123.456.78.9'})
+    expect(tracker.__tracks.length).toEqual(1)
+    expect(tracker.__tracks[0].remoteIp).toEqual('123.456.78.9')
   })
 
   it('catches and logs errors', async () => {

--- a/lib/__mocks__/tracker.js
+++ b/lib/__mocks__/tracker.js
@@ -1,9 +1,18 @@
-const tracker = jest.genMockFromModule('../tracker')
+const tracker = require.requireActual('../tracker')
 
-beforeEach(() => tracker.__log = [])
+beforeEach(() => {
+  tracker.__reasons = []
+  tracker.__skips = []
+  tracker.__tracks = []
+})
 
-tracker.log = async function(query, headers, identity) {
-  tracker.__log.push({query, headers, identity})
-}
+jest.spyOn(tracker, 'logReason').mockImplementation(async (reason, data) => {
+  if (reason) {
+    tracker.__reasons.push(reason)
+    tracker.__skips.push(data)
+  } else {
+    tracker.__tracks.push(data)
+  }
+})
 
 module.exports = tracker

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -15,5 +15,10 @@ exports.put = async function(json) {
     StreamName = StreamName.split('/').pop()
   }
 
-  await kinesis.putRecord({Data, PartitionKey, StreamName}).promise()
+  if (StreamName) {
+    await kinesis.putRecord({Data, PartitionKey, StreamName}).promise()
+    return true
+  } else {
+    return false
+  }
 }

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -1,0 +1,19 @@
+const AWS = require('aws-sdk')
+const crypto = require('crypto')
+const kinesis = new AWS.Kinesis({region: process.env.AWS_REGION || 'us-east-1'})
+
+/**
+ * Write a pixel tracker record to kinesis
+ */
+exports.put = async function(json) {
+  const Data = JSON.stringify(json)
+  const PartitionKey = crypto.createHash('md5').update(Data).digest('hex')
+
+  // convert full arns to stream name
+  let StreamName = process.env.KINESIS_STREAM || ''
+  if (StreamName.indexOf('/') > -1) {
+    StreamName = StreamName.split('/').pop()
+  }
+
+  await kinesis.putRecord({Data, PartitionKey, StreamName}).promise()
+}

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -1,0 +1,49 @@
+jest.mock('aws-sdk')
+
+const sdk = require('aws-sdk')
+const kinesis = require('./kinesis')
+
+
+describe('kinesis', () => {
+
+  it('puts data to kinesis', async () => {
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(1)
+    expect(sdk.__kinesisPuts[0].Data).toEqual('{"foo":"bar"}')
+  })
+
+  it('sets a unique partition key', async () => {
+    await kinesis.put({foo: 'bar1'})
+    await kinesis.put({foo: 'bar1'})
+    await kinesis.put({foo: 'bar2'})
+    await kinesis.put({foo: 'bar3'})
+    expect(sdk.__kinesisPuts.length).toEqual(4)
+    expect(sdk.__kinesisPuts[0].PartitionKey).toEqual(sdk.__kinesisPuts[1].PartitionKey)
+    expect(sdk.__kinesisPuts[0].PartitionKey).not.toEqual(sdk.__kinesisPuts[2].PartitionKey)
+    expect(sdk.__kinesisPuts[0].PartitionKey).not.toEqual(sdk.__kinesisPuts[3].PartitionKey)
+  })
+
+  it('sets a kinesis stream', async () => {
+    process.env.KINESIS_STREAM = 'anything'
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(1)
+    expect(sdk.__kinesisPuts[0].StreamName).toEqual('anything')
+  })
+
+  it('decodes kinesis stream arns', async () => {
+    process.env.KINESIS_STREAM = 'arn:aws:kinesis:us-east-1:12345678:stream/anything'
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(1)
+    expect(sdk.__kinesisPuts[0].StreamName).toEqual('anything')
+  })
+
+  it('throws kinesis errors', async () => {
+    try {
+      await kinesis.put({throw: true})
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(err.message).toMatch(/FakeKinesis throws error/)
+    }
+  })
+
+})

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -6,6 +6,8 @@ const kinesis = require('./kinesis')
 
 describe('kinesis', () => {
 
+  beforeEach(() => process.env.KINESIS_STREAM = 'test-stream')
+
   it('puts data to kinesis', async () => {
     await kinesis.put({foo: 'bar'})
     expect(sdk.__kinesisPuts.length).toEqual(1)
@@ -28,6 +30,12 @@ describe('kinesis', () => {
     await kinesis.put({foo: 'bar'})
     expect(sdk.__kinesisPuts.length).toEqual(1)
     expect(sdk.__kinesisPuts[0].StreamName).toEqual('anything')
+  })
+
+  it('ignores puts with no stream set', async () => {
+    process.env.KINESIS_STREAM = ''
+    await kinesis.put({foo: 'bar'})
+    expect(sdk.__kinesisPuts.length).toEqual(0)
   })
 
   it('decodes kinesis stream arns', async () => {

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -1,4 +1,5 @@
 const log = require('lambda-log')
+const kinesis = require('./kinesis')
 const signer = require('./signer')
 const util = require('./util')
 
@@ -10,23 +11,26 @@ exports.log = async (query, headers, identity) => {
   headers = headers || {}
   identity = identity || {}
 
-  const agent = headers['user-agent']
-  const ip = headers['x-forwarded-for'] || identity['sourceIp']
-  const referrer = headers['referer']
+  const remoteAgent = headers['user-agent']
+  const remoteIp = headers['x-forwarded-for'] || identity['sourceIp']
+  const remoteReferrer = headers['referer']
+
+  // kinesis record MUST match analytics-ingest-lambda PixelTrackers input
   const data = {
     key: query['k'],
     canonical: query['c'],
     destination: query['d'],
-    agent,
-    ip,
-    referrer,
+    remoteAgent,
+    remoteIp,
+    remoteReferrer,
   }
 
-  const reason = skipReason(query, agent, ip)
+  const reason = skipReason(query, remoteAgent, remoteIp)
   if (reason) {
     log.info('skip', {reason, ...data})
   } else {
     log.info('track', data)
+    await kinesis.put({type: 'pixel', timestamp: Date.now(), ...data})
   }
 }
 

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -6,7 +6,7 @@ const util = require('./util')
 /**
  * Log a pixel tracking impression
  */
-exports.log = async (query, headers, identity) => {
+exports.log = async (query, headers, identity, userId) => {
   query = query || {}
   headers = headers || {}
   identity = identity || {}
@@ -23,6 +23,7 @@ exports.log = async (query, headers, identity) => {
     remoteAgent,
     remoteIp,
     remoteReferrer,
+    userId,
   }
 
   const reason = skipReason(query, remoteAgent, remoteIp)

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -6,7 +6,7 @@ const util = require('./util')
 /**
  * Log a pixel tracking impression
  */
-exports.log = async (query, headers, identity, userId) => {
+exports.log = (query, headers, identity, userId) => {
   query = query || {}
   headers = headers || {}
   identity = identity || {}
@@ -27,11 +27,20 @@ exports.log = async (query, headers, identity, userId) => {
   }
 
   const reason = skipReason(query, remoteAgent, remoteIp)
+  return exports.logReason(reason, data)
+}
+
+/**
+ * Actual logging
+ */
+exports.logReason = async (reason, data) => {
   if (reason) {
     log.info('skip', {reason, ...data})
+    return false
   } else {
     log.info('track', data)
     await kinesis.put({type: 'pixel', timestamp: Date.now(), ...data})
+    return true
   }
 }
 

--- a/lib/tracker.test.js
+++ b/lib/tracker.test.js
@@ -9,7 +9,14 @@ describe('tracker', () => {
   const query = signer.signObject({k: 'my-key', c: 'my-url', d: 'my-dest'})
   const headers = {'user-agent': 'my-agent', 'x-forwarded-for': 'my-ip', 'referer': 'my-ref'}
   const identity = {sourceIp: 'source-ip'}
-  const myData = {agent: 'my-agent', canonical: 'my-url', destination: 'my-dest', ip: 'my-ip', key: 'my-key', referrer: 'my-ref'}
+  const myData = {
+    canonical: 'my-url',
+    destination: 'my-dest',
+    key: 'my-key',
+    remoteAgent: 'my-agent',
+    remoteIp: 'my-ip',
+    remoteReferrer: 'my-ref',
+  }
 
   it('tracks pixel impressions', async () => {
     await tracker.log(query, headers)
@@ -50,35 +57,35 @@ describe('tracker', () => {
     await tracker.log(query, {...headers, 'user-agent': null})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('skip')
-    expect(log.__info[0].data).toEqual({...myData, agent: null, reason: 'no-agent'})
+    expect(log.__info[0].data).toEqual({...myData, remoteAgent: null, reason: 'no-agent'})
   })
 
   it('falls back to the identity source ip', async () => {
     await tracker.log(query, {...headers, 'x-forwarded-for': null}, identity)
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('track')
-    expect(log.__info[0].data).toEqual({...myData, ip: 'source-ip'})
+    expect(log.__info[0].data).toEqual({...myData, remoteIp: 'source-ip'})
   })
 
   it('skips lack of ip address', async () => {
     await tracker.log(query, {...headers, 'x-forwarded-for': null}, {sourceIp: null})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('skip')
-    expect(log.__info[0].data).toEqual({...myData, ip: null, reason: 'no-ip'})
+    expect(log.__info[0].data).toEqual({...myData, remoteIp: null, reason: 'no-ip'})
   })
 
   it('allows lack of referrer', async () => {
     await tracker.log(query, {...headers, 'referer': undefined})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('track')
-    expect(log.__info[0].data).toEqual({...myData, referrer: undefined})
+    expect(log.__info[0].data).toEqual({...myData, remoteReferrer: undefined})
   })
 
   it('skips bots', async () => {
     await tracker.log(query, {...headers, 'user-agent': 'GoogleBot'})
     expect(log.__info.length).toEqual(1)
     expect(log.__info[0].msg).toEqual('skip')
-    expect(log.__info[0].data).toEqual({...myData, agent: 'GoogleBot', reason: 'bot'})
+    expect(log.__info[0].data).toEqual({...myData, remoteAgent: 'GoogleBot', reason: 'bot'})
   })
 
 })

--- a/lib/tracker.test.js
+++ b/lib/tracker.test.js
@@ -88,4 +88,9 @@ describe('tracker', () => {
     expect(log.__info[0].data).toEqual({...myData, remoteAgent: 'GoogleBot', reason: 'bot'})
   })
 
+  it('optionally sets a user id', async () => {
+    await tracker.log(query, headers, identity, 'my-user-id')
+    expect(log.__info[0].data).toEqual({...myData, userId: 'my-user-id'})
+  })
+
 })

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,5 @@
 const isBot = require('isbot')
+const querystring = require('querystring')
 const {base64Pixel, pixelSize} = require('./constants')
 
 /**
@@ -20,10 +21,39 @@ exports.keysToLowerCase = (obj) => {
 }
 
 /**
+ * Query param object to string
+ */
+exports.encodeQuery = (obj) => {
+  if (obj && Object.keys(obj).length > 0) {
+    return '?' + querystring.stringify(obj)
+  } else {
+    return ''
+  }
+}
+
+/**
+ * In the year 2000...
+ */
+exports.future = (addYears = 1, now = new Date()) => {
+  const d = new Date(now)
+  d.setFullYear(d.getFullYear() + addYears)
+  return d
+}
+
+/**
  * API Gateway responses
  */
 exports.text = (statusCode, body) => {
   return {statusCode, body, headers: {'content-type': 'text/plain'}}
+}
+exports.redirect = (location, setCookie) => {
+  const body = `Redirecting to ${location}`
+  const headers = {location, 'content-type': 'text/plain'}
+  if (setCookie) {
+    return {statusCode: 302, body, headers: {...headers, 'set-cookie': setCookie}}
+  } else {
+    return {statusCode: 302, body, headers}
+  }
 }
 exports.html = body => {
   return {statusCode: 200, body, headers: {'content-type': 'text/html'}}

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -17,11 +17,41 @@ describe('util', () => {
     expect(util.keysToLowerCase({heLlo: '1'}).hello).toEqual('1')
   })
 
+  it('encodes a query object', () => {
+    expect(util.encodeQuery()).toEqual('')
+    expect(util.encodeQuery({})).toEqual('')
+    expect(util.encodeQuery({foo: 'bar', a: 'b'})).toEqual('?foo=bar&a=b')
+    expect(util.encodeQuery({hello: 'esc=ap&stuff'})).toEqual('?hello=esc%3Dap%26stuff')
+  })
+
+  it('adds years to dates', () => {
+    const date = new Date('1999-01-01')
+    expect(util.future(1, date).toISOString()).toEqual('2000-01-01T00:00:00.000Z')
+    expect(util.future(2, date).toISOString()).toEqual('2001-01-01T00:00:00.000Z')
+    expect(util.future(5, date).toISOString()).toEqual('2004-01-01T00:00:00.000Z')
+  })
+
   it('returns api gateway text', () => {
     expect(util.text(123, 'anything')).toEqual({
       statusCode: 123,
       body: 'anything',
       headers: {'content-type': 'text/plain'}
+    })
+  })
+
+  it('returns api gateway redirects', () => {
+    expect(util.redirect('/some/where')).toEqual({
+      statusCode: 302,
+      body: 'Redirecting to /some/where',
+      headers: {'content-type': 'text/plain', 'location': '/some/where'},
+    })
+  })
+
+  it('returns api gateway redirects with a cookie', () => {
+    expect(util.redirect('/some/where', 'set=the-cookie')).toEqual({
+      statusCode: 302,
+      body: 'Redirecting to /some/where',
+      headers: {'content-type': 'text/plain', 'location': '/some/where', 'set-cookie': 'set=the-cookie'},
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   },
   "homepage": "https://github.com/PRX/pixel.prx.org",
   "dependencies": {
+    "cookie": "^0.3.1",
     "isbot": "^2.2.1",
-    "lambda-log": "^2.2.0"
+    "lambda-log": "^2.2.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "aws-sdk": "^2.448.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lambda-log": "^2.2.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.448.0",
     "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "jest": "^24.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,7 +834,7 @@ cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
 
-cookie@0.3.1:
+cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,21 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
+aws-sdk@^2.448.0:
+  version "2.448.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.448.0.tgz#1afa8bc1616aa6bacba393d70923e4294febe430"
+  integrity sha512-RMmdxP0VgI8eq7SehOHINULL6BL84wy9jOngQwJnxCPT/3/5jUuexKjzeFpdXTS4+dVToqj8q9THAbqzuXZ9dQ==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -513,6 +528,11 @@ babel-preset-jest@^24.6.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -604,6 +624,15 @@ bser@^2.0.0:
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1080,6 +1109,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -1510,6 +1544,16 @@ iconv-lite@0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -1747,7 +1791,7 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -2161,6 +2205,11 @@ jest@^24.7.1:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.7.1"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -2952,6 +3001,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2968,6 +3022,11 @@ qs@^6.5.1:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.0:
   version "1.2.0"
@@ -3185,7 +3244,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -3682,6 +3746,14 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -3701,7 +3773,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
@@ -3836,6 +3908,19 @@ xdg-basedir@^3.0.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
For #4.  Must merge after #6.

Pixel tracker user ids.  When a request comes in to `/i.gif`:

- `/i.gif` or `/r.gif` - If there is a `_pxid` cookie, return the pixel and log to kinesis with a `userId`
- `/i.gif` - If there is no `_pxid` cookie set, redirect to `/r.gif` with a set-cookie header
- `/r.gif` - If there is no `_pxid` set, return the pixel and log to kinesis without a `userId`